### PR TITLE
feat: add option to use user-mounted exports file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN apk add --no-cache nfs-utils bash && \
 
 COPY exports /etc/
 COPY nfsd.sh /usr/bin/nfsd.sh
+COPY exports.sh /usr/bin/exports.sh
 
-RUN chmod +x /usr/bin/nfsd.sh
+RUN chmod +x /usr/bin/nfsd.sh /usr/bin/exports.sh
 
 ENTRYPOINT ["/usr/bin/nfsd.sh"]

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ The /etc/exports file contains these parameters unless modified by the environme
 
 Note that the `showmount` command won't work against the server as rpcbind isn't running.
 
+### Mounting your own exports (advanced)
+
+To mount a custom exports file, set `-e EXPORTS_MOUNTED=true` and mount a valid exports file at `/etc/exports`. **Warning:** If this environment variable is set none of the other configuration env variables will have any effect. Use with caution.
+
 ### Privileged Mode
 
 You'll note above with the `docker run` command that privileged mode is required. Yes, this is a security risk but an unavoidable one it seems. You could try these instead: `--cap-add SYS_ADMIN --cap-add SETPCAP --security-opt=no-new-privileges` but I've not had any luck with them myself. You may fare better with your own combination of Docker and OS. The SYS_ADMIN capability is very, very broad in any case and almost as risky as privileged mode.

--- a/exports.sh
+++ b/exports.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+rm /etc/exports
+
+# Check if the SHARED_DIRECTORY variable is empty
+if [ -z "${SHARED_DIRECTORY}" ]; then
+  echo "The SHARED_DIRECTORY environment variable is unset or null, exiting..."
+  exit 1
+else
+  echo "Writing SHARED_DIRECTORY to /etc/exports file"
+  echo "{{SHARED_DIRECTORY}} {{PERMITTED}}({{READ_ONLY}},fsid=0,{{SYNC}},no_subtree_check,no_auth_nlm,insecure,no_root_squash)" >> /etc/exports
+  /bin/sed -i "s@{{SHARED_DIRECTORY}}@${SHARED_DIRECTORY}@g" /etc/exports
+fi
+
+# This is here to demonsrate how multiple directories can be shared. You
+# would need a block like this for each extra share.
+# Any additional shares MUST be subdirectories of the root directory specified
+# by SHARED_DIRECTORY.
+
+# Check if the SHARED_DIRECTORY_2 variable is empty
+if [ ! -z "${SHARED_DIRECTORY_2}" ]; then
+  echo "Writing SHARED_DIRECTORY_2 to /etc/exports file"
+  echo "{{SHARED_DIRECTORY_2}} {{PERMITTED}}({{READ_ONLY}},{{SYNC}},no_subtree_check,no_auth_nlm,insecure,no_root_squash)" >> /etc/exports
+  /bin/sed -i "s@{{SHARED_DIRECTORY_2}}@${SHARED_DIRECTORY_2}@g" /etc/exports
+fi
+
+# Check if the PERMITTED variable is empty
+if [ -z "${PERMITTED}" ]; then
+  echo "The PERMITTED environment variable is unset or null, defaulting to '*'."
+  echo "This means any client can mount."
+  /bin/sed -i "s/{{PERMITTED}}/*/g" /etc/exports
+else
+  echo "The PERMITTED environment variable is set."
+  echo "The permitted clients are: ${PERMITTED}."
+  /bin/sed -i "s/{{PERMITTED}}/"${PERMITTED}"/g" /etc/exports
+fi
+
+# Check if the READ_ONLY variable is set (rather than a null string) using parameter expansion
+if [ -z ${READ_ONLY+y} ]; then
+  echo "The READ_ONLY environment variable is unset or null, defaulting to 'rw'."
+  echo "Clients have read/write access."
+  /bin/sed -i "s/{{READ_ONLY}}/rw/g" /etc/exports
+else
+  echo "The READ_ONLY environment variable is set."
+  echo "Clients will have read-only access."
+  /bin/sed -i "s/{{READ_ONLY}}/ro/g" /etc/exports
+fi
+
+# Check if the SYNC variable is set (rather than a null string) using parameter expansion
+if [ -z "${SYNC+y}" ]; then
+  echo "The SYNC environment variable is unset or null, defaulting to 'async' mode".
+  echo "Writes will not be immediately written to disk."
+  /bin/sed -i "s/{{SYNC}}/async/g" /etc/exports
+else
+  echo "The SYNC environment variable is set, using 'sync' mode".
+  echo "Writes will be immediately written to disk."
+  /bin/sed -i "s/{{SYNC}}/sync/g" /etc/exports
+fi

--- a/nfsd.sh
+++ b/nfsd.sh
@@ -20,61 +20,15 @@ stop()
   exit
 }
 
-rm /etc/exports
-
-# Check if the SHARED_DIRECTORY variable is empty
-if [ -z "${SHARED_DIRECTORY}" ]; then
-  echo "The SHARED_DIRECTORY environment variable is unset or null, exiting..."
+if [ -z "${EXPORTS_MOUNTED}" ]; then
+  echo "Building /etc/exports file..."
+  /usr/bin/exports.sh
+# EXPORTS_MOUNTED is set, ensure a file is mounted
+elif [ -f /etc/exports ]; then
+  echo "Skipping creation of /etc/exports, user has set EXPORTS_MOUNTED and mounted a file at /etc/exports"
+else
+  echo "EXPORTS_MOUNTED is set but no file found at /etc/exports. Exiting..."
   exit 1
-else
-  echo "Writing SHARED_DIRECTORY to /etc/exports file"
-  echo "{{SHARED_DIRECTORY}} {{PERMITTED}}({{READ_ONLY}},fsid=0,{{SYNC}},no_subtree_check,no_auth_nlm,insecure,no_root_squash)" >> /etc/exports
-  /bin/sed -i "s@{{SHARED_DIRECTORY}}@${SHARED_DIRECTORY}@g" /etc/exports
-fi
-
-# This is here to demonsrate how multiple directories can be shared. You
-# would need a block like this for each extra share.
-# Any additional shares MUST be subdirectories of the root directory specified
-# by SHARED_DIRECTORY.
-
-# Check if the SHARED_DIRECTORY_2 variable is empty
-if [ ! -z "${SHARED_DIRECTORY_2}" ]; then
-  echo "Writing SHARED_DIRECTORY_2 to /etc/exports file"
-  echo "{{SHARED_DIRECTORY_2}} {{PERMITTED}}({{READ_ONLY}},{{SYNC}},no_subtree_check,no_auth_nlm,insecure,no_root_squash)" >> /etc/exports
-  /bin/sed -i "s@{{SHARED_DIRECTORY_2}}@${SHARED_DIRECTORY_2}@g" /etc/exports
-fi
-
-# Check if the PERMITTED variable is empty
-if [ -z "${PERMITTED}" ]; then
-  echo "The PERMITTED environment variable is unset or null, defaulting to '*'."
-  echo "This means any client can mount."
-  /bin/sed -i "s/{{PERMITTED}}/*/g" /etc/exports
-else
-  echo "The PERMITTED environment variable is set."
-  echo "The permitted clients are: ${PERMITTED}."
-  /bin/sed -i "s/{{PERMITTED}}/"${PERMITTED}"/g" /etc/exports
-fi
-
-# Check if the READ_ONLY variable is set (rather than a null string) using parameter expansion
-if [ -z ${READ_ONLY+y} ]; then
-  echo "The READ_ONLY environment variable is unset or null, defaulting to 'rw'."
-  echo "Clients have read/write access."
-  /bin/sed -i "s/{{READ_ONLY}}/rw/g" /etc/exports
-else
-  echo "The READ_ONLY environment variable is set."
-  echo "Clients will have read-only access."
-  /bin/sed -i "s/{{READ_ONLY}}/ro/g" /etc/exports
-fi
-
-# Check if the SYNC variable is set (rather than a null string) using parameter expansion
-if [ -z "${SYNC+y}" ]; then
-  echo "The SYNC environment variable is unset or null, defaulting to 'async' mode".
-  echo "Writes will not be immediately written to disk."
-  /bin/sed -i "s/{{SYNC}}/async/g" /etc/exports
-else
-  echo "The SYNC environment variable is set, using 'sync' mode".
-  echo "Writes will be immediately written to disk."
-  /bin/sed -i "s/{{SYNC}}/sync/g" /etc/exports
 fi
 
 # Partially set 'unofficial Bash Strict Mode' as described here: http://redsymbol.net/articles/unofficial-bash-strict-mode/


### PR DESCRIPTION
This PR adds a EXPORTS_MOUNTED environment variable which skips the custom creation based on env variables

I also split the exports generation logic from the main nfsd.sh script into exports.sh, I think it's cleaner that way and allows for more custom container logic e.g. overriding the entrypoint but keeping the settings from nfsd.sh.

I pushed an image to `docker.io/ant385525/alpine-nfs` if you'd like to test